### PR TITLE
Fix Backward twice ERROR

### DIFF
--- a/models/conditional_gan_model.py
+++ b/models/conditional_gan_model.py
@@ -89,7 +89,7 @@ class ConditionalGAN(BaseModel):
 	def backward_D(self):
 		self.loss_D = self.discLoss.get_loss(self.netD, self.real_A, self.fake_B, self.real_B)
 
-		self.loss_D.backward()
+		self.loss_D.backward(retain_graph=True)
 
 	def backward_G(self):
 		self.loss_G_GAN = self.discLoss.get_g_loss(self.netD, self.real_A, self.fake_B)


### PR DESCRIPTION
Hello @KupynOrest 

As diccussion in https://discuss.pytorch.org/t/runtimeerror-trying-to-backward-through-the-graph-a-second-time-but-the-buffers-have-already-been-freed-specify-retain-graph-true-when-calling-backward-the-first-time/6795/2
 For new version of pytorch, all intermediate result will be delete to reduce memory . So when using your code the following error happened. Same as https://github.com/KupynOrest/DeblurGAN/issues/56

```
RuntimeError: Trying to backward through the graph a second time, 
but the buffers have already been freed. Specify retain_graph=True 
when calling backward the first time.

```

I made a pull request to fix that error